### PR TITLE
Better error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,7 +128,8 @@ func (s *StirrClient) FillCache() error {
 		fmt.Print(".")
 		status, statusErr := s.GetChannel(channel.DisplayName)
 		if statusErr != nil {
-			return statusErr
+			log.Println("Ignoring error on", channel.DisplayName, ":", statusErr)
+			return nil
 		}
 		status.Number = idx + 1
 

--- a/main.go
+++ b/main.go
@@ -71,6 +71,10 @@ func (s *StirrClient) makeRequest(url string, output interface{}) error {
 		defer res.Body.Close()
 	}
 
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected response %v from %v", res.Status, url)
+	}
+
 	body, readErr := ioutil.ReadAll(res.Body)
 	if readErr != nil {
 		return readErr


### PR DESCRIPTION
Fixes issue causing crash on boot:

```
2022/07/10 12:44:09 Beginning cache fill
2022/07/10 12:44:09 Found 111 channels in lineup, getting channel metadata and guide. This may take a moment.
..2022/07/10 12:44:10 Error when filling cache unexpected end of JSON input
```